### PR TITLE
Want to make the encryption module have unified traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ bincode = "1.3.3"
 thiserror = "1.0"
 num-bigint = "0.4"
 num-integer = "0.1"
+typenum = "1.15.0"
+generic-array = "0.14.5"
 rand = "0.8.5"
 rand_core = "0.6"
 schnorrkel = { version = "0.9.1", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1", features = ["full"], optional = true }
 hyper = { version = "0.14", features = ["full"], optional = true }
-futures = { version = "0.3", optional = true}
+futures = { version = "0.3", optional = true }
 leveldb = { version = "0.8.6", optional = true }
 structopt = { version = "0.3", default-features = false, optional = true }
 lazy_static = "1.4"
@@ -20,10 +20,25 @@ db-key = "0.0.5"
 ff = { version = "0.11", features = ["derive"] }
 sha3 = "0.10.0"
 bincode = "1.3.3"
-rand = "0.8.5"
 thiserror = "1.0"
 num-bigint = "0.4"
 num-integer = "0.1"
+rand = "0.8.5"
+rand_core = "0.6"
+schnorrkel = { version = "0.9.1", features = [
+    "preaudit_deprecated",
+    "u64_backend",
+    "getrandom",
+    "rand",
+    "std"
+], default-features = false }
+merlin = "2.0.0"
+hex = "0.4.3"
+hmac = "0.11.0"
+pbkdf2 = "0.8.0"
+sha2 = "0.9"
+zeroize = "1.0"
+tiny-bip39 = "0.8.0"
 
 [features]
 node = ["tokio", "hyper", "leveldb", "futures", "structopt"]

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -1,7 +1,8 @@
+use thiserror::Error;
+
 use crate::config::genesis;
 use crate::core::{Address, Block, Money, Transaction};
 use crate::db::{KvStore, KvStoreError, RamMirrorKvStore, StringKey, WriteOp};
-use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum BlockchainError {

--- a/src/core/bip39.rs
+++ b/src/core/bip39.rs
@@ -1,0 +1,34 @@
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
+use schnorrkel::keys::MiniSecretKey;
+use sha2::Sha512;
+use zeroize::Zeroize;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
+pub enum Error {
+    #[error("entropy has an invalid length")]
+    InvalidEntropy,
+}
+
+pub fn mini_secret_from_entropy(entropy: &[u8], password: &str) -> Result<MiniSecretKey, Error> {
+    let seed = seed_from_entropy(entropy, password)?;
+    Ok(MiniSecretKey::from_bytes(&seed[..32]).expect("Length is always correct;"))
+}
+
+pub fn seed_from_entropy(entropy: &[u8], password: &str) -> Result<[u8; 64], Error> {
+    if entropy.len() < 16 || entropy.len() > 32 || entropy.len() % 4 != 0 {
+        return Err(Error::InvalidEntropy);
+    }
+
+    let mut salt = String::with_capacity(8 + password.len());
+    salt.push_str("mnemonic");
+    salt.push_str(password);
+
+    let mut seed = [0u8; 64];
+
+    pbkdf2::<Hmac<Sha512>>(entropy, salt.as_bytes(), 2048, &mut seed);
+
+    salt.zeroize();
+
+    Ok(seed)
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,7 @@ use crate::core::number::U256;
 use crate::crypto;
 use crate::crypto::SignatureScheme;
 
+pub mod bip39;
 pub mod blocks;
 pub mod digest;
 pub mod hash;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,9 +1,15 @@
+use std::hash::Hash;
+
+use rand_core::{OsRng, RngCore};
+
+pub use eddsa::*;
+pub use mimc::*;
+
 mod curve;
 mod eddsa;
 mod field;
 mod mimc;
-pub use eddsa::*;
-pub use mimc::*;
+mod sr25519;
 
 pub trait SignatureScheme {
     type Pub;
@@ -22,4 +28,133 @@ pub trait VerifiableRandomFunction {
     fn generate(seed: &[u8]) -> (Self::Pub, Self::Priv);
     fn evaluate(sk: &Self::Priv, input: &[u8]) -> (Self::Output, Self::Proof);
     fn verify(pk: &Self::Pub, input: &[u8], output: &Self::Output, proof: &Self::Proof) -> bool;
+}
+
+pub trait CryptoCorrelation {
+    type Pair: PairT;
+}
+
+pub trait PublicT:
+    CryptoCorrelation
+    + AsRef<[u8]>
+    + AsMut<[u8]>
+    + Default
+    + PartialEq
+    + Eq
+    + Clone
+    + Send
+    + Sync
+    + for<'a> TryFrom<&'a [u8]>
+{
+    /// A new instance from
+    fn from_slice(data: &[u8]) -> Self;
+
+    fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    fn to_raw_vec(&self) -> Vec<u8> {
+        self.as_slice().to_vec()
+    }
+
+    fn to_public(&self) -> CryptoIdWithPublic;
+}
+
+pub trait CanBeTranscript {
+    fn as_merlin_transcript(&self) -> merlin::Transcript;
+}
+
+pub trait VRFPublic: PublicT {
+    type VRFPair: VRFPair;
+
+    fn vrf_verify(
+        &self,
+        data: <<Self as VRFPublic>::VRFPair as VRFPair>::VRFData,
+        sig: <<Self as VRFPublic>::VRFPair as VRFPair>::VRFSignature,
+    ) -> Result<schnorrkel::vrf::VRFInOut, Error>;
+}
+
+pub trait VRFSignature {
+    fn output(&self) -> &schnorrkel::vrf::VRFOutput;
+    fn proof(&self) -> &schnorrkel::vrf::VRFProof;
+}
+
+pub trait VRFPair: PairT {
+    type VRFData: CanBeTranscript;
+    type VRFSignature: VRFSignature + AsRef<[u8]>;
+    type VRFPublic: PublicT + Hash + VRFPublic;
+
+    fn vrf_sign(&self, data: Self::VRFData) -> Self::VRFSignature;
+}
+
+pub trait PairT: CryptoCorrelation + Sized + Clone + Send + Sync + 'static {
+    type Public: PublicT + Hash;
+
+    type Seed: Default + AsRef<[u8]> + AsMut<[u8]> + Clone;
+
+    type Signature: AsRef<[u8]> + CryptoCorrelation;
+
+    /// generate a ephemeral instance, since you won't have access to the secret key to storage
+    fn generate() -> (Self, Self::Seed) {
+        let mut seed = Self::Seed::default();
+        OsRng.fill_bytes(seed.as_mut());
+        (Self::from_seed(&seed), seed)
+    }
+
+    /// generate new secure (random) key pair and provide the recovery phrase.
+    fn generate_with_phrase(password: Option<&str>) -> (Self, String, Self::Seed);
+
+    /// generate new one from the English BIP39 seed `phrase`, or `None` if it's invalid.
+    fn from_phrase(phrase: &str, password: Option<&str>) -> Result<(Self, Self::Seed), Error>;
+
+    fn from_seed(seed: &Self::Seed) -> Self;
+
+    fn from_seed_slice(seed: &[u8]) -> Result<Self, Error>;
+
+    fn sign(&self, message: &[u8]) -> Self::Signature;
+
+    fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool;
+}
+
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct CryptoId(pub [u8; 4]);
+
+#[derive(
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct CryptoIdWithPublic(pub CryptoId, pub Vec<u8>);
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("vrf error: {0}")]
+    VRFSignatureError(schnorrkel::errors::SignatureError),
+    #[error("the seed is invalid")]
+    InvalidSeed,
+    #[error("the {0} has an invalid length")]
+    InvalidLength(String),
+    #[error("{0}")]
+    Custom(String),
+    #[error("The seed phrase provided is not a valid BIP39 phrase")]
+    InvalidPhrase,
 }

--- a/src/crypto/sr25519.rs
+++ b/src/crypto/sr25519.rs
@@ -1,0 +1,481 @@
+use std::ops::Deref;
+
+use bip39::{Language, Mnemonic, MnemonicType};
+use merlin::Transcript;
+use schnorrkel::keys::{MINI_SECRET_KEY_LENGTH, SECRET_KEY_LENGTH};
+use schnorrkel::vrf::{VRFInOut, VRFOutput, VRFProof, VRF_PROOF_LENGTH};
+use schnorrkel::{
+    signing_context, ExpansionMode, MiniSecretKey, PublicKey, SecretKey, PUBLIC_KEY_LENGTH,
+};
+
+use crate::core::bip39::mini_secret_from_entropy;
+use crate::crypto::{
+    CanBeTranscript, CryptoCorrelation, CryptoIdWithPublic, PairT, PublicT, VRFPair, VRFPublic,
+};
+use crate::crypto::{CryptoId, Error};
+
+const SIGNING_CTX: &[u8] = b"sr25_123_0990";
+pub const CRYPTO_ID: CryptoId = CryptoId(*b"sr25");
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
+pub struct Public(pub [u8; 32]);
+
+impl VRFPublic for Public {
+    type VRFPair = Pair;
+
+    fn vrf_verify(
+        &self,
+        data: <<Self as VRFPublic>::VRFPair as VRFPair>::VRFData,
+        sig: <<Self as VRFPublic>::VRFPair as VRFPair>::VRFSignature,
+    ) -> Result<VRFInOut, Error> {
+        let transcript = make_transcript(&data);
+        let public =
+            schnorrkel::PublicKey::from_bytes(&self.0).map_err(|e| Error::VRFSignatureError(e))?;
+        let (inout, _) = public
+            .vrf_verify(transcript, &sig.output, &sig.proof)
+            .map_err(|e| Error::VRFSignatureError(e))?;
+        Ok(inout)
+    }
+}
+
+impl PublicT for Public {
+    fn from_slice(data: &[u8]) -> Self {
+        let mut r = [0u8; 32];
+        r.copy_from_slice(data);
+        Public(r)
+    }
+
+    fn to_public(&self) -> CryptoIdWithPublic {
+        CryptoIdWithPublic(CRYPTO_ID, self.to_raw_vec())
+    }
+}
+
+impl AsRef<[u8; 32]> for Public {
+    fn as_ref(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Public {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl AsMut<[u8]> for Public {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0[..]
+    }
+}
+
+impl Deref for Public {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Public> for [u8; 32] {
+    fn from(x: Public) -> [u8; 32] {
+        x.0
+    }
+}
+
+impl core::convert::TryFrom<&[u8]> for Public {
+    type Error = Error;
+
+    fn try_from(data: &[u8]) -> Result<Self, Error> {
+        if data.len() == 32 {
+            let mut inner = [0u8; 32];
+            inner.copy_from_slice(data);
+            Ok(Public(inner))
+        } else {
+            Err(Error::InvalidLength("sr25519's public".to_string()))
+        }
+    }
+}
+
+/// Schnorrkel/Ristretto "sr25519" key pair.
+pub struct Pair(schnorrkel::Keypair);
+
+impl VRFPair for Pair {
+    type VRFData = VRFTranscriptData;
+    type VRFSignature = VRFSignature;
+    type VRFPublic = Public;
+
+    fn vrf_sign(&self, data: Self::VRFData) -> Self::VRFSignature {
+        let transcript = make_transcript(&data);
+        let (inout, proof, _) = self.0.vrf_sign(transcript);
+        VRFSignature {
+            output: inout.to_output(),
+            proof,
+        }
+    }
+}
+
+impl Clone for Pair {
+    fn clone(&self) -> Self {
+        Pair(schnorrkel::Keypair {
+            public: self.0.public,
+            secret: schnorrkel::SecretKey::from_bytes(&self.0.secret.to_bytes()[..])
+                .expect("key is always the correct size"),
+        })
+    }
+}
+
+impl From<MiniSecretKey> for Pair {
+    fn from(sec: MiniSecretKey) -> Pair {
+        Pair(sec.expand_to_keypair(ExpansionMode::Ed25519))
+    }
+}
+
+impl From<SecretKey> for Pair {
+    fn from(sec: SecretKey) -> Pair {
+        Pair(schnorrkel::Keypair::from(sec))
+    }
+}
+
+impl From<schnorrkel::Keypair> for Pair {
+    fn from(p: schnorrkel::Keypair) -> Pair {
+        Pair(p)
+    }
+}
+
+impl From<Pair> for schnorrkel::Keypair {
+    fn from(p: Pair) -> schnorrkel::Keypair {
+        p.0
+    }
+}
+
+impl AsRef<schnorrkel::Keypair> for Pair {
+    fn as_ref(&self) -> &schnorrkel::Keypair {
+        &self.0
+    }
+}
+
+impl Pair {
+    pub fn from_entropy(entropy: &[u8], password: Option<&str>) -> (Pair, Seed) {
+        let mini_key: MiniSecretKey = mini_secret_from_entropy(entropy, password.unwrap_or(""))
+            .expect("32 bytes can always build a key;");
+
+        let kp = mini_key.expand_to_keypair(ExpansionMode::Ed25519);
+        (Pair(kp), mini_key.to_bytes())
+    }
+
+    pub fn from_seed_slice(seed: &[u8]) -> Result<Self, Error> {
+        match seed.len() {
+            MINI_SECRET_KEY_LENGTH => Ok(Pair(
+                MiniSecretKey::from_bytes(seed)
+                    .map_err(|_| Error::InvalidSeed)?
+                    .expand_to_keypair(ExpansionMode::Ed25519),
+            )),
+            SECRET_KEY_LENGTH => Ok(Pair(
+                SecretKey::from_bytes(seed)
+                    .map_err(|_| Error::InvalidSeed)?
+                    .to_keypair(),
+            )),
+            _ => Err(Error::InvalidLength("seed".to_string())),
+        }
+    }
+
+    pub fn to_public(&self) -> Public {
+        Public(self.0.public.to_bytes())
+    }
+}
+
+impl PairT for Pair {
+    type Public = Public;
+    type Seed = Seed;
+    type Signature = Signature;
+
+    fn generate_with_phrase(password: Option<&str>) -> (Self, String, Self::Seed) {
+        let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
+        let phrase = mnemonic.phrase();
+        let (pair, seed) = Self::from_phrase(phrase, password)
+            .expect("All phrases generated by Mnemonic are valid; qed");
+        (pair, phrase.to_owned(), seed)
+    }
+
+    fn from_phrase(phrase: &str, password: Option<&str>) -> Result<(Self, Self::Seed), Error> {
+        Mnemonic::from_phrase(phrase, Language::English)
+            .map_err(|_| Error::InvalidPhrase)
+            .map(|m| Self::from_entropy(m.entropy(), password))
+    }
+
+    fn from_seed(seed: &Self::Seed) -> Self {
+        Self::from_seed_slice(&seed[..]).expect("32 bytes can always build a key;")
+    }
+
+    fn from_seed_slice(seed: &[u8]) -> Result<Self, Error> {
+        Self::from_seed_slice(seed)
+    }
+
+    fn sign(&self, message: &[u8]) -> Self::Signature {
+        let context = signing_context(SIGNING_CTX);
+        self.0.sign(context.bytes(message)).into()
+    }
+
+    fn verify<M: AsRef<[u8]>>(sig: &Self::Signature, message: M, pubkey: &Self::Public) -> bool {
+        let signature = match schnorrkel::Signature::from_bytes(&sig.0) {
+            Ok(signature) => signature,
+            Err(_) => return false,
+        };
+
+        let pub_key = match PublicKey::from_bytes(pubkey.as_ref()) {
+            Ok(pub_key) => pub_key,
+            Err(_) => return false,
+        };
+        pub_key
+            .verify_simple(SIGNING_CTX, message.as_ref(), &signature)
+            .is_ok()
+    }
+}
+
+type Seed = [u8; MINI_SECRET_KEY_LENGTH];
+
+pub struct Signature(pub [u8; 64]);
+
+impl Clone for Signature {
+    fn clone(&self) -> Self {
+        let mut r = [0u8; 64];
+        r.copy_from_slice(&self.0[..]);
+        Signature(r)
+    }
+}
+
+impl core::convert::TryFrom<&[u8]> for Signature {
+    type Error = ();
+
+    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+        if data.len() == 64 {
+            let mut inner = [0u8; 64];
+            inner.copy_from_slice(data);
+            Ok(Signature(inner))
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl serde::Serialize for Signature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&hex::encode(self))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Signature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let signature_hex = hex::decode(&String::deserialize(deserializer)?)
+            .map_err(|e| serde::de::Error::custom(format!("{:?}", e)))?;
+        Signature::try_from(signature_hex.as_ref())
+            .map_err(|e| serde::de::Error::custom(format!("{:?}", e)))
+    }
+}
+
+impl Default for Signature {
+    fn default() -> Self {
+        Signature([0u8; 64])
+    }
+}
+
+impl PartialEq for Signature {
+    fn eq(&self, b: &Self) -> bool {
+        self.0[..] == b.0[..]
+    }
+}
+
+impl Eq for Signature {}
+
+impl From<Signature> for [u8; 64] {
+    fn from(v: Signature) -> [u8; 64] {
+        v.0
+    }
+}
+
+impl AsRef<[u8; 64]> for Signature {
+    fn as_ref(&self) -> &[u8; 64] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Signature {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl AsMut<[u8]> for Signature {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0[..]
+    }
+}
+
+impl From<schnorrkel::Signature> for Signature {
+    fn from(s: schnorrkel::Signature) -> Signature {
+        Signature(s.to_bytes())
+    }
+}
+
+impl std::hash::Hash for Signature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::hash::Hash::hash(&self.0[..], state);
+    }
+}
+
+impl CryptoCorrelation for Pair {
+    type Pair = Pair;
+}
+
+impl CryptoCorrelation for Public {
+    type Pair = Pair;
+}
+
+impl CryptoCorrelation for Signature {
+    type Pair = Pair;
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub enum VRFTranscriptValue {
+    /// Value is an array of bytes
+    Bytes(Vec<u8>),
+    /// Value is a u64 integer
+    U64(u64),
+}
+
+#[derive(Clone)]
+pub struct VRFTranscriptData {
+    pub label: &'static [u8],
+    pub items: Vec<(&'static str, VRFTranscriptValue)>,
+}
+
+impl CanBeTranscript for VRFTranscriptData {
+    fn as_merlin_transcript(&self) -> Transcript {
+        make_transcript(&self)
+    }
+}
+
+pub struct VRFSignature {
+    /// The VRFOutput serialized
+    pub output: VRFOutput,
+    /// The calculated VRFProof
+    pub proof: VRFProof,
+}
+
+impl AsRef<[u8]> for VRFSignature {
+    // @TODO: unsafe or some better way
+    fn as_ref(&self) -> &[u8] {
+        let mut misk = vec![0u8; PUBLIC_KEY_LENGTH + VRF_PROOF_LENGTH];
+        let (prefix, suffifx) = misk.split_at_mut(PUBLIC_KEY_LENGTH);
+        prefix.copy_from_slice(&self.output.0);
+        suffifx.copy_from_slice(&self.proof.to_bytes());
+        misk.leak()
+    }
+}
+
+impl crate::crypto::VRFSignature for VRFSignature {
+    fn output(&self) -> &VRFOutput {
+        &self.output
+    }
+
+    fn proof(&self) -> &VRFProof {
+        &self.proof
+    }
+}
+
+/// convert to `merlin Transcript`
+pub fn make_transcript(data: &VRFTranscriptData) -> Transcript {
+    let mut transcript = Transcript::new(data.label);
+    for (label, value) in data.items.iter() {
+        match value {
+            VRFTranscriptValue::Bytes(ref bytes) => {
+                transcript.append_message((*label).as_bytes(), &bytes);
+            }
+            VRFTranscriptValue::U64(ref val) => {
+                transcript.append_u64((*label).as_bytes(), *val);
+            }
+        }
+    }
+    transcript
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::crypto::sr25519::{Pair, VRFTranscriptData, VRFTranscriptValue};
+    use crate::crypto::{PairT, VRFPair, VRFPublic};
+
+    #[test]
+    fn sign_and_verify() {
+        let pair = Pair::from_seed_slice(b"12345678901234567890123456789012")
+            .expect("create sr25519 pair");
+        let sig = pair.sign(b"friendly");
+        let public = pair.to_public();
+        assert!(Pair::verify(&sig, b"friendly", &public));
+
+        assert!(!Pair::verify(&sig, b"not friendly", &public));
+    }
+
+    #[test]
+    fn vrf_test_ok() {
+        let pair = Pair::from_seed_slice(b"12345678901234567890123456789012")
+            .expect("create sr25519 pair");
+        let sig = pair.vrf_sign(VRFTranscriptData {
+            label: b"a label",
+            items: vec![
+                ("one", VRFTranscriptValue::U64(1)),
+                ("two", VRFTranscriptValue::Bytes("two".as_bytes().to_vec())),
+            ],
+        });
+        assert!(pair
+            .to_public()
+            .vrf_verify(
+                VRFTranscriptData {
+                    label: b"a label",
+                    items: vec![
+                        ("one", VRFTranscriptValue::U64(1)),
+                        ("two", VRFTranscriptValue::Bytes("two".as_bytes().to_vec())),
+                    ],
+                },
+                sig,
+            )
+            .is_ok())
+    }
+
+    #[test]
+    fn vrf_test_not_ok() {
+        let pair = Pair::from_seed_slice(b"12345678901234567890123456789012")
+            .expect("create sr25519 pair");
+        let sig = pair.vrf_sign(VRFTranscriptData {
+            label: b"alice",
+            items: vec![
+                ("one", VRFTranscriptValue::U64(1)),
+                (
+                    "now alice has one",
+                    VRFTranscriptValue::Bytes("now alice has one".as_bytes().to_vec()),
+                ),
+            ],
+        });
+        assert!(pair
+            .to_public()
+            .vrf_verify(
+                VRFTranscriptData {
+                    label: b"fake label",
+                    items: vec![
+                        ("two", VRFTranscriptValue::U64(2)),
+                        (
+                            "now alice has two",
+                            VRFTranscriptValue::Bytes("now alice has two".as_bytes().to_vec()),
+                        ),
+                    ],
+                },
+                sig,
+            )
+            .is_err())
+    }
+}


### PR DESCRIPTION
## Why ?
Because all the crypto pairs would be stored or generated from a module called `keystore` or something else. I think it's better to make them (eddsa, sr25519, bls381) having the same traits. For instance, node need to do a VRF via matching public key which is part of sr25519. 

## Modify What ?
The behavior of encryption is abstracted on mod `crypto`
Add a new mod Sr25519.


Hey Keyvank, there is still one problem in this commit.  Can I just convert the `PublicKey` and in eddsa directly into byte array  `[u8; 33]`? 
