### PR TITLE
Fix the `#![feature(const_panic)]` issue from the deepest dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ num-bigint = "0.4"
 num-integer = "0.1"
 lru = "0.7.5"
 hex = "0.4.3"
-zeekit = "0.1.1"
+zeekit = { git = "https://github.com/zeeka-network/zeekit.git", tag = "v0.1.2" }
 
 # Node related deps
 tokio = { version = "1", features = ["full"], optional = true }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-10-28
+stable

--- a/src/crypto/eddsa.rs
+++ b/src/crypto/eddsa.rs
@@ -89,13 +89,13 @@ impl SignatureScheme for EdDSA {
 
 #[cfg(test)]
 mod tests {
+    use zeekit::Fr;
+    use zeekit::eddsa::BASE;
     use super::*;
 
     #[test]
     fn test_public_key_compression() {
-        let scalar = U256::generate(b"hi");
-        let p1 = BASE.multiply(&scalar);
-
+        let p1 = BASE.multiply(&Fr::from(123 as u64));
         let p2 = p1.compress().decompress();
 
         assert_eq!(p1, p2);
@@ -107,6 +107,7 @@ mod tests {
         let msg = b"Hi this a transaction!";
         let fake_msg = b"Hi this a fake transaction!";
         let sig = EdDSA::sign(&sk, msg);
+
         assert!(EdDSA::verify(&pk, msg, &sig));
         assert!(!EdDSA::verify(&pk, fake_msg, &sig));
     }


### PR DESCRIPTION
I forked all dusk deps and fixed the following issue. Two things to mention:

- I pushed to a number of repos. This was 'cas no code changes was included and I wanted to fix this minor issue fast. This wouldn't be a manner
- I used tags instead of crates.io packages for a number of repos.
- Build on this branch still fails because of an issue in a previously added test, which I could fix in a future PR. Without that test, everything works well.
- If you're considering using cartesio, please push the latest zeekit to the registery
- We're now using the stable channel 🥂

The issue: https://github.com/zeeka-network/bazuka/runs/6197985406?check_suite_focus=true#step:3:320