### PR TITLE
Abstract simulated Network for testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,14 @@ hyper = { version = "0.14", features = ["full"], optional = true }
 futures = { version = "0.3", optional = true }
 leveldb = { version = "0.8.6", optional = true }
 structopt = { version = "0.3", default-features = false, optional = true }
+async-trait = { version = "0.1.53", optional = true }
 
 # Proof-of-Work related deps
 rust-randomx = { version = "0.5.5", optional = true }
 
 [features]
 default = ["node", "pow"]
-node = ["tokio", "hyper", "leveldb", "futures", "structopt"]
+node = ["tokio", "hyper", "leveldb", "futures", "structopt", "async-trait"]
 pow = ["rust-randomx"]
 
 [patch.crates-io]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use {
     bazuka::node::{Internet, Node, NodeError, PeerAddress},
     bazuka::wallet::Wallet,
     std::path::{Path, PathBuf},
+    std::sync::Arc,
     structopt::StructOpt,
 };
 
@@ -47,7 +48,7 @@ lazy_static! {
         {
             let opts = OPTS.clone();
             Node::new(
-                Internet::new(),
+                Arc::new(Internet::new()),
                 PeerAddress(
                     opts.host
                         .unwrap_or_else(|| "127.0.0.1".to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate lazy_static;
 use {
     bazuka::blockchain::KvStoreChain,
     bazuka::db::{LevelDbKvStore, LruCacheKvStore},
-    bazuka::node::{Node, NodeError, PeerAddress},
+    bazuka::node::{Internet, Node, NodeError, PeerAddress},
     bazuka::wallet::Wallet,
     std::path::{Path, PathBuf},
     structopt::StructOpt,
@@ -43,10 +43,11 @@ lazy_static! {
 #[cfg(feature = "node")]
 lazy_static! {
     static ref OPTS: NodeOptions = NodeOptions::from_args();
-    static ref NODE: Node<KvStoreChain<LruCacheKvStore<LevelDbKvStore>>> =
+    static ref NODE: Node<Internet, KvStoreChain<LruCacheKvStore<LevelDbKvStore>>> =
         {
             let opts = OPTS.clone();
             Node::new(
+                Internet::new(),
                 PeerAddress(
                     opts.host
                         .unwrap_or_else(|| "127.0.0.1".to_string())

--- a/src/node/api/get_blocks.rs
+++ b/src/node/api/get_blocks.rs
@@ -1,12 +1,12 @@
 use super::messages::{GetBlocksRequest, GetBlocksResponse};
-use super::{NodeContext, NodeError};
+use super::{Network, NodeContext, NodeError};
 use crate::blockchain::Blockchain;
 use crate::config::MAX_BLOCK_FETCH;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn get_blocks<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn get_blocks<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     req: GetBlocksRequest,
 ) -> Result<GetBlocksResponse, NodeError> {
     let context = context.read().await;

--- a/src/node/api/get_headers.rs
+++ b/src/node/api/get_headers.rs
@@ -1,11 +1,11 @@
 use super::messages::{GetHeadersRequest, GetHeadersResponse};
-use super::{NodeContext, NodeError};
+use super::{Network, NodeContext, NodeError};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn get_headers<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn get_headers<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     req: GetHeadersRequest,
 ) -> Result<GetHeadersResponse, NodeError> {
     let context = context.read().await;

--- a/src/node/api/get_miner_puzzle.rs
+++ b/src/node/api/get_miner_puzzle.rs
@@ -1,11 +1,11 @@
 use super::messages::{GetMinerPuzzleRequest, Puzzle};
-use super::{NodeContext, NodeError};
+use super::{Network, NodeContext, NodeError};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn get_miner_puzzle<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn get_miner_puzzle<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     _req: GetMinerPuzzleRequest,
 ) -> Result<Puzzle, NodeError> {
     let mut context = context.write().await;

--- a/src/node/api/get_peers.rs
+++ b/src/node/api/get_peers.rs
@@ -1,11 +1,11 @@
 use super::messages::{GetPeersRequest, GetPeersResponse};
-use super::{NodeContext, NodeError};
+use super::{Network, NodeContext, NodeError};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn get_peers<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn get_peers<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     _req: GetPeersRequest,
 ) -> Result<GetPeersResponse, NodeError> {
     let context = context.read().await;

--- a/src/node/api/get_stats.rs
+++ b/src/node/api/get_stats.rs
@@ -1,11 +1,11 @@
 use super::messages::{GetStatsRequest, GetStatsResponse};
-use super::{NodeContext, NodeError};
+use super::{Network, NodeContext, NodeError};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn get_stats<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn get_stats<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     _req: GetStatsRequest,
 ) -> Result<GetStatsResponse, NodeError> {
     let context = context.read().await;

--- a/src/node/api/mod.rs
+++ b/src/node/api/mod.rs
@@ -1,4 +1,4 @@
-use super::{NodeContext, NodeError, Peer, PeerAddress, PeerInfo, TransactionStats};
+use super::{Network, NodeContext, NodeError, Peer, PeerAddress, PeerInfo, TransactionStats};
 
 pub mod messages;
 

--- a/src/node/api/post_block.rs
+++ b/src/node/api/post_block.rs
@@ -1,11 +1,11 @@
 use super::messages::{PostBlockRequest, PostBlockResponse};
-use super::{NodeContext, NodeError};
+use super::{Network, NodeContext, NodeError};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn post_block<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn post_block<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     req: PostBlockRequest,
 ) -> Result<PostBlockResponse, NodeError> {
     let mut context = context.write().await;

--- a/src/node/api/post_miner.rs
+++ b/src/node/api/post_miner.rs
@@ -1,11 +1,11 @@
 use super::messages::{RegisterMinerRequest, RegisterMinerResponse};
-use super::{Miner, NodeContext, NodeError};
+use super::{Miner, Network, NodeContext, NodeError};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn post_miner<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn post_miner<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     req: RegisterMinerRequest,
 ) -> Result<RegisterMinerResponse, NodeError> {
     let mut context = context.write().await;

--- a/src/node/api/post_miner_solution.rs
+++ b/src/node/api/post_miner_solution.rs
@@ -1,11 +1,11 @@
 use super::messages::{PostMinerSolutionRequest, PostMinerSolutionResponse};
-use super::{NodeContext, NodeError};
+use super::{Network, NodeContext, NodeError};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn post_miner_solution<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn post_miner_solution<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     req: PostMinerSolutionRequest,
 ) -> Result<PostMinerSolutionResponse, NodeError> {
     let mut context = context.write().await;

--- a/src/node/api/post_peer.rs
+++ b/src/node/api/post_peer.rs
@@ -1,11 +1,11 @@
 use super::messages::{PostPeerRequest, PostPeerResponse};
-use super::{NodeContext, NodeError, Peer};
+use super::{Network, NodeContext, NodeError, Peer};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn post_peer<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn post_peer<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     req: PostPeerRequest,
 ) -> Result<PostPeerResponse, NodeError> {
     let mut context = context.write().await;

--- a/src/node/api/transact.rs
+++ b/src/node/api/transact.rs
@@ -1,11 +1,11 @@
 use super::messages::{TransactRequest, TransactResponse};
-use super::{NodeContext, NodeError, TransactionStats};
+use super::{Network, NodeContext, NodeError, TransactionStats};
 use crate::blockchain::Blockchain;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub async fn transact<B: Blockchain>(
-    context: Arc<RwLock<NodeContext<B>>>,
+pub async fn transact<B: Blockchain, N: Network>(
+    context: Arc<RwLock<NodeContext<N, B>>>,
     req: TransactRequest,
 ) -> Result<TransactResponse, NodeError> {
     let mut context = context.write().await;

--- a/src/node/context.rs
+++ b/src/node/context.rs
@@ -1,3 +1,4 @@
+use super::http::Network;
 use super::{Peer, PeerAddress, PeerInfo};
 use crate::blockchain::{Blockchain, BlockchainError};
 use crate::core::Transaction;
@@ -6,6 +7,7 @@ use crate::wallet::Wallet;
 use rand::seq::IteratorRandom;
 use rand::RngCore;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[cfg(feature = "pow")]
 use {super::api::messages::Puzzle, crate::core::Block};
@@ -24,7 +26,8 @@ pub struct Miner {
     pub webhook: Option<String>,
 }
 
-pub struct NodeContext<B: Blockchain> {
+pub struct NodeContext<N: Network, B: Blockchain> {
+    pub network: Arc<N>,
     pub blockchain: B,
     pub wallet: Option<Wallet>,
     pub mempool: HashMap<Transaction, TransactionStats>,
@@ -34,7 +37,7 @@ pub struct NodeContext<B: Blockchain> {
     pub miner: Option<Miner>,
 }
 
-impl<B: Blockchain> NodeContext<B> {
+impl<N: Network, B: Blockchain> NodeContext<N, B> {
     pub fn network_timestamp(&self) -> u32 {
         (utils::local_timestamp() as i32 + self.timestamp_offset) as u32
     }

--- a/src/node/heartbeat/log_info.rs
+++ b/src/node/heartbeat/log_info.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-pub async fn log_info<B: Blockchain>(
-    context: &Arc<RwLock<NodeContext<B>>>,
+pub async fn log_info<B: Blockchain, N: Network>(
+    context: &Arc<RwLock<NodeContext<N, B>>>,
 ) -> Result<(), NodeError> {
     let ctx = context.read().await;
     let mut inf = Vec::new();

--- a/src/node/heartbeat/send_mining_puzzle.rs
+++ b/src/node/heartbeat/send_mining_puzzle.rs
@@ -1,15 +1,19 @@
 use super::*;
 
-pub async fn send_mining_puzzle<B: Blockchain>(
-    context: &Arc<RwLock<NodeContext<B>>>,
+pub async fn send_mining_puzzle<N: Network, B: Blockchain>(
+    context: &Arc<RwLock<NodeContext<N, B>>>,
 ) -> Result<(), NodeError> {
     let mut ctx = context.write().await;
+
+    let net = Arc::clone(&ctx.network);
+
     if let Some(w) = ctx.wallet.clone() {
         let (blk, puzzle) = ctx.get_puzzle(w)?;
         if let Some(m) = &mut ctx.miner {
             if m.block_puzzle.is_none() {
                 if let Some(webhook) = m.webhook.clone() {
-                    http::json_post::<Puzzle, String>(webhook.to_string(), puzzle.clone()).await?;
+                    net.json_post::<Puzzle, String>(webhook.to_string(), puzzle.clone())
+                        .await?;
                     m.block_puzzle = Some((blk, puzzle));
                 }
             }

--- a/src/node/http.rs
+++ b/src/node/http.rs
@@ -1,65 +1,106 @@
+use async_trait::async_trait;
+
 use super::{NodeError, PeerAddress};
 use futures::future::join_all;
 use hyper::{Body, Client, Method, Request};
 
-pub async fn bincode_get<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
-    addr: String,
-    req: Req,
-) -> Result<Resp, NodeError> {
-    let client = Client::new();
-    let req = Request::builder()
-        .method(Method::GET)
-        .uri(format!("{}?{}", addr, serde_qs::to_string(&req)?))
-        .body(Body::empty())?;
-    let body = client.request(req).await?.into_body();
-    let resp: Resp = bincode::deserialize(&hyper::body::to_bytes(body).await?)?;
-    Ok(resp)
+#[async_trait(?Send)]
+pub trait Network {
+    async fn bincode_get<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        addr: String,
+        req: Req,
+    ) -> Result<Resp, NodeError>;
+    async fn bincode_post<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        addr: String,
+        req: Req,
+    ) -> Result<Resp, NodeError>;
+    async fn json_get<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        addr: String,
+        req: Req,
+    ) -> Result<Resp, NodeError>;
+    async fn json_post<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        addr: String,
+        req: Req,
+    ) -> Result<Resp, NodeError>;
 }
 
-#[allow(dead_code)]
-pub async fn bincode_post<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
-    addr: String,
-    req: Req,
-) -> Result<Resp, NodeError> {
-    let client = Client::new();
-    let req = Request::builder()
-        .method(Method::POST)
-        .uri(&addr)
-        .header("content-type", "application/octet-stream")
-        .body(Body::from(bincode::serialize(&req)?))?;
-    let body = client.request(req).await?.into_body();
-    let resp: Resp = bincode::deserialize(&hyper::body::to_bytes(body).await?)?;
-    Ok(resp)
+pub struct Internet;
+
+impl Internet {
+    pub fn new() -> Self {
+        Self {}
+    }
 }
 
-pub async fn json_post<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
-    addr: String,
-    req: Req,
-) -> Result<Resp, NodeError> {
-    let client = Client::new();
-    let req = Request::builder()
-        .method(Method::POST)
-        .uri(&addr)
-        .header("content-type", "application/json")
-        .body(Body::from(serde_json::to_vec(&req)?))?;
-    let body = client.request(req).await?.into_body();
-    let resp: Resp = serde_json::from_slice(&hyper::body::to_bytes(body).await?)?;
-    Ok(resp)
-}
+#[async_trait(?Send)]
+impl Network for Internet {
+    async fn bincode_get<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        addr: String,
+        req: Req,
+    ) -> Result<Resp, NodeError> {
+        let client = Client::new();
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(format!("{}?{}", addr, serde_qs::to_string(&req)?))
+            .body(Body::empty())?;
+        let body = client.request(req).await?.into_body();
+        let resp: Resp = bincode::deserialize(&hyper::body::to_bytes(body).await?)?;
+        Ok(resp)
+    }
 
-#[allow(dead_code)]
-pub async fn json_get<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
-    addr: String,
-    req: Req,
-) -> Result<Resp, NodeError> {
-    let client = Client::new();
-    let req = Request::builder()
-        .method(Method::GET)
-        .uri(format!("{}?{}", addr, serde_qs::to_string(&req)?))
-        .body(Body::empty())?;
-    let body = client.request(req).await?.into_body();
-    let resp: Resp = serde_json::from_slice(&hyper::body::to_bytes(body).await?)?;
-    Ok(resp)
+    #[allow(dead_code)]
+    async fn bincode_post<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        addr: String,
+        req: Req,
+    ) -> Result<Resp, NodeError> {
+        let client = Client::new();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(&addr)
+            .header("content-type", "application/octet-stream")
+            .body(Body::from(bincode::serialize(&req)?))?;
+        let body = client.request(req).await?.into_body();
+        let resp: Resp = bincode::deserialize(&hyper::body::to_bytes(body).await?)?;
+        Ok(resp)
+    }
+
+    async fn json_post<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        addr: String,
+        req: Req,
+    ) -> Result<Resp, NodeError> {
+        let client = Client::new();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(&addr)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&req)?))?;
+        let body = client.request(req).await?.into_body();
+        let resp: Resp = serde_json::from_slice(&hyper::body::to_bytes(body).await?)?;
+        Ok(resp)
+    }
+
+    #[allow(dead_code)]
+    async fn json_get<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        addr: String,
+        req: Req,
+    ) -> Result<Resp, NodeError> {
+        let client = Client::new();
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(format!("{}?{}", addr, serde_qs::to_string(&req)?))
+            .body(Body::empty())?;
+        let body = client.request(req).await?.into_body();
+        let resp: Resp = serde_json::from_slice(&hyper::body::to_bytes(body).await?)?;
+        Ok(resp)
+    }
 }
 
 pub async fn group_request<F, R>(

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -27,7 +27,7 @@ use hyper::server::conn::AddrStream;
 use tokio::sync::RwLock;
 use tokio::try_join;
 
-pub use http::{Network, Internet};
+pub use http::{Internet, Network};
 
 pub type Timestamp = u32;
 
@@ -177,7 +177,7 @@ impl<
     > Node<N, B>
 {
     pub fn new(
-        network: N,
+        network: Arc<N>,
         address: PeerAddress,
         bootstrap: Vec<PeerAddress>,
         blockchain: B,
@@ -186,7 +186,7 @@ impl<
         Node {
             address,
             context: Arc::new(RwLock::new(NodeContext {
-                network: Arc::new(network),
+                network,
                 blockchain,
                 wallet,
                 mempool: HashMap::new(),


### PR DESCRIPTION
@krypton193 Hey, I'm passing an abstracted `Network` object to `Node` so that we can control side-effects of the node functions and be able to test them with a simulated network. A default `Internet` implementation is also provided for the `Network` trait, which just calls, well, the actual Internet :slightly_smiling_face: 